### PR TITLE
feat: finalized block and extend chain refactor

### DIFF
--- a/demo.sh
+++ b/demo.sh
@@ -43,29 +43,29 @@ function insert_headers_fork_potential() {
 }
 
 # Get last block
-function latest_block() {
+function head() {
     LC_ID=$1
-    sui client call --function latest_block --module light_client --package $PACKAGE_ID --gas-budget 10000000 --args $LC_ID --dev-inspect
+    sui client call --function head --module light_client --package $PACKAGE_ID --gas-budget 10000000 --args $LC_ID --dev-inspect
 }
 
 case "$1" in
-    create_lc)
-	create_light_client
-	;;
-    insert_headers)
-	insert_headers $2
-	;;
-    insert_headers_fork)
-	insert_headers_fork_potential $2
-	;;
-    latest_block)
-	latest_block $2
-	;;
-    lc_object)
-	client_object $2
-	;;
-    *)
-	echo "Invalid option."
-	exit 1
-	;;
+create_lc)
+    create_light_client
+    ;;
+insert_headers)
+    insert_headers $2
+    ;;
+insert_headers_fork)
+    insert_headers_fork_potential $2
+    ;;
+head)
+    head $2
+    ;;
+lc_object)
+    client_object $2
+    ;;
+*)
+    echo "Invalid option."
+    exit 1
+    ;;
 esac

--- a/sources/block_header.move
+++ b/sources/block_header.move
@@ -32,6 +32,7 @@ public fun version(header: &BlockHeader): u32 {
     to_u32(header.slice(0, 4))
 }
 
+/// return parent block hash
 public fun prev_block(header: &BlockHeader): vector<u8> {
     header.slice(4, 36)
 }

--- a/sources/light_client.move
+++ b/sources/light_client.move
@@ -20,7 +20,7 @@ const EBlockNotFound: u64 = 5;
 const EForkChainWorkTooSmall: u64 = 6;
 const ETxNotInBlock: u64 = 7;
 
-const FINALITY_CONF: u8 = 8;
+const FINALITY_CONF: u64 = 8;
 
 public struct NewLightClientEvent has copy, drop {
     light_client_id: ID
@@ -250,6 +250,10 @@ public fun head(lc: &LightClient): &LightBlock {
     lc.get_light_block_by_hash(lc.head_hash)
 }
 
+/// Returns latest finalized_block height
+public fun finalized_height(lc: &LightClient): u64 {
+    lc.head_height - FINALITY_CONF
+}
 
 /// verify output transaction
 /// * `height`: block heigh transacion belong

--- a/sources/light_client.move
+++ b/sources/light_client.move
@@ -247,10 +247,7 @@ public fun head_hash(lc: &LightClient): vector<u8> {
 
 /// Returns blockchain head light block (latest, not confirmed block).
 public fun head(lc: &LightClient): &LightBlock {
-    let block_hash = lc.get_block_hash_by_height(lc.head_height);
-    lc.get_light_block_by_hash(block_hash)
-    // TODO: find why this doesn't work
-    // lc.get_light_block_by_hash(lc.head_hash)
+    lc.get_light_block_by_hash(lc.head_hash)
 }
 
 

--- a/sources/light_client.move
+++ b/sources/light_client.move
@@ -60,7 +60,7 @@ public(package) fun new_light_client_with_params_int(params: Params, start_heigh
         params: params,
         head_height: 0,
         head_hash: vector[],
-        finality: finality,
+        finality,
     };
 
     let mut current_chain_work = start_chain_work;
@@ -94,8 +94,14 @@ public(package) fun new_light_client_with_params_int(params: Params, start_heigh
 /// Encode header reference:
 /// https://developer.bitcoin.org/reference/block_chain.html#block-headers
 public fun new_light_client_with_params(params: Params, start_height: u64, trusted_headers: vector<vector<u8>>, start_chain_work: u256, ctx: &mut TxContext) {
-    let lc = new_light_client_with_params_int(params,
-        start_height, trusted_headers, start_chain_work, 8, ctx);
+    let lc = new_light_client_with_params_int(
+            params,
+            start_height,
+            trusted_headers,
+            start_chain_work, 
+            8, 
+            ctx
+        );
     event::emit(NewLightClientEvent {
         light_client_id: object::id(&lc)
     });

--- a/tests/difficulty_tests.move
+++ b/tests/difficulty_tests.move
@@ -58,7 +58,7 @@ fun test_difficulty_computation_mainnet() {
     let sender = @0x01;
     let mut scenario = test_scenario::begin(sender);
 
-    let mut lc = new_light_client_with_params_int(params::mainnet(), 0, vector[x"0100000000000000000000000000000000000000000000000000000000000000000000003ba3edfd7a7b12b27ac72c3e67768f617fc81bc3888a51323a9fb8aa4b1e5e4a29ab5f49ffff001d1dac2b7c"], 0, scenario.ctx());
+    let mut lc = new_light_client_with_params_int(params::mainnet(), 0, vector[x"0100000000000000000000000000000000000000000000000000000000000000000000003ba3edfd7a7b12b27ac72c3e67768f617fc81bc3888a51323a9fb8aa4b1e5e4a29ab5f49ffff001d1dac2b7c"], 0, 8, scenario.ctx());
 
     let block_hash = lc.get_block_hash_by_height(0);
 
@@ -101,6 +101,7 @@ fun test_difficulty_computation_regtest() {
         // this is power_limit.
         vector[x"0040a320aa52a8971f61e56bf5a45117e3e224eabfef9237cb9a0100000000000000000060a9a5edd4e39b70ee803e3d22673799ae6ec733ea7549442324f9e3a790e4e4b806e1665b250317807427ca"],
         0,
+        8,
         scenario.ctx()
     );
 
@@ -122,6 +123,7 @@ fun test_testnet_reset_dificulty() {
         // This header is random, we only care about timestamp in this case.
         vector[x"000000207e50e267813c0b5849307d9a604a3250d122e5b25080950200000000000000007243a2960f9c5db0623a4b3c77a57bbe262d906e8d94dc837f032269bcaf8eeb77fd0058c440041806bc3f79"],
         0,
+        8,
         scenario.ctx()
     );
 
@@ -145,6 +147,7 @@ fun test_testnet_use_previous_difficulty() {
         // This header is random, we only care about timestamp in this case.
         vector[x"000000207e50e267813c0b5849307d9a604a3250d122e5b25080950200000000000000007243a2960f9c5db0623a4b3c77a57bbe262d906e8d94dc837f032269bcaf8eeb77fd0058c440041806bc3f79"],
         0,
+        8,
         scenario.ctx()
     );
     let last_block = lc.get_light_block_by_height(10);
@@ -171,6 +174,7 @@ fun test_find_prev_testnet_difficulty() {
         x"000000207e50e267813c0b5849307d9a604a3250d122e5b25080950200000000000000007243a2960f9c5db0623a4b3c77a57bbe262d906e8d94dc837f032269bcaf8eeb77fd00587856341206bc3f79"
     ],
         0,
+        8,
         scenario.ctx()
     );
 

--- a/tests/difficulty_tests.move
+++ b/tests/difficulty_tests.move
@@ -74,11 +74,11 @@ fun test_difficulty_computation_mainnet() {
 
     let last_block_hash = last_block.header().block_hash();
     lc.set_block_hash_by_height(last_block.height(), last_block_hash);
-    lc.add_light_block(last_block);
+    lc.append_block(last_block);
     let header = new_block_header(x"0060b0329fd61df7a284ba2f7debbfaef9c5152271ef8165037300000000000000000000562139850fcfc2eb3204b1e790005aaba44e63a2633252fdbced58d2a9a87e2cdb34cf665b250317245ddc6a");
     let first_block = new_light_block(858816,   header, 0);
     lc.set_block_hash_by_height(first_block.height(), first_block.header().block_hash());
-    lc.add_light_block(first_block);
+    lc.append_block(first_block);
 
 
     let new_bits = calc_next_required_difficulty(&lc, lc.get_light_block_by_hash(last_block_hash), 0);
@@ -191,7 +191,7 @@ fun test_find_prev_testnet_difficulty() {
     );
 
     lc.set_block_hash_by_height(0, genesis_block.header().block_hash());
-    lc.add_light_block(genesis_block);
+    lc.append_block(genesis_block);
 
     // return power limit when genesis block
     assert!(lc.find_prev_testnet_difficulty(lc.get_light_block_by_height(0)) == lc.params().power_limit_bits());

--- a/tests/fork_tests.move
+++ b/tests/fork_tests.move
@@ -32,7 +32,7 @@ fun new_lc_for_test(ctx: &mut TxContext): (LightClient, vector<BlockHeader>) {
         x"0000003040ce8b407650044a4294fd43c6d78cbb4f78ac98527f858f3950dad92fc5982ddebd5d70e4be4f6f5cc474416137a697f1fca22bf87e9066eb9b43dd7882d23239c5b167ffff7f2002000000"
     ];
 
-    let lc = new_light_client_with_params_int(params::regtest(), 0, headers, 0, ctx);
+    let lc = new_light_client_with_params_int(params::regtest(), 0, headers, 0, 8, ctx);
 
     let block_headers = headers.map!(|h| new_block_header(h));
     (lc, block_headers)

--- a/tests/fork_tests.move
+++ b/tests/fork_tests.move
@@ -71,8 +71,8 @@ fun insert_headers_switch_fork_tests() {
         insert_point = insert_point + 1;
     });
 
-    assert!(lc.latest_block().height() == insert_point - 1);
-    assert!(lc.latest_block().header() == last_header);
+    assert!(lc.head().height() == insert_point - 1);
+    assert!(lc.head().header() == last_header);
     sui::test_utils::destroy(lc);
     scenario.end();
 }
@@ -123,9 +123,10 @@ fun rollback_tests() {
     let (mut lc, headers) =  new_lc_for_test(ctx);
 
     let checkpoint = headers[5].block_hash();
-    let latest_block = lc.latest_block().header().block_hash();
+    // TODO: head().header().block_hash()
+    let head = lc.head().header().block_hash();
 
-    lc.rollback(checkpoint, latest_block);
+    lc.rollback(checkpoint, head);
 
     let height = lc.get_light_block_by_hash(checkpoint).height();
     let mut i = 0u64;

--- a/tests/fork_tests.move
+++ b/tests/fork_tests.move
@@ -123,10 +123,8 @@ fun rollback_tests() {
     let (mut lc, headers) =  new_lc_for_test(ctx);
 
     let checkpoint = headers[5].block_hash();
-    // TODO: head().header().block_hash()
-    let head = lc.head().header().block_hash();
-
-    lc.rollback(checkpoint, head);
+    let head_hash = lc.head_hash();
+    lc.rollback(checkpoint, head_hash);
 
     let height = lc.get_light_block_by_hash(checkpoint).height();
     let mut i = 0u64;

--- a/tests/light_client_tests.move
+++ b/tests/light_client_tests.move
@@ -70,11 +70,10 @@ fun test_insert_header_happy_cases() {
         x"00801e31c24ae25304cbac7c3d3b076e241abb20ff2da1d3ddfc00000000000000000000530e6745eca48e937428b0f15669efdce807a071703ed5a4df0e85a3f6cc0f601c35cf665b25031780f1e351"
     ];
     lc.insert_headers(raw_headers);
-    let latest_hash = lc.head_hash();
-    let latest_block = lc.get_light_block_by_hash(latest_hash).header();
+    let head_block = lc.get_light_block_by_hash(lc.head_hash()).header();
 
-    assert!(latest_block == new_block_header(raw_headers[0]));
-    assert!(latest_block == lc.head().header());
+    assert!(head_block == new_block_header(raw_headers[0]));
+    assert!(head_block == lc.head().header());
 
     let last_block_header = new_block_header(x"0040a320aa52a8971f61e56bf5a45117e3e224eabfef9237cb9a0100000000000000000060a9a5edd4e39b70ee803e3d22673799ae6ec733ea7549442324f9e3a790e4e4b806e1665b250317807427ca");
     let last_block = new_light_block(
@@ -102,8 +101,8 @@ fun test_insert_header_failed_block_hash_not_match() {
     let mut lc = new_lc_for_test(scenario.ctx());
     // we changed the block hash to make new header previous hash not match with last hash
     let new_header = new_block_header(x"00801e31c24ae25304cbac7c3d3b076e241abb20ff2da1d3ddfc00000000000000000001530e6745eca48e937428b0f15669efdce807a071703ed5a4df0e85a3f6cc0f601c35cf665b25031780f1e351");
-    let current_block_hash = lc.head().header().block_hash();
-    lc.insert_header(current_block_hash, new_header);
+    let head_hash = lc.head_hash();
+    lc.insert_header(head_hash, new_header);
 
     sui::test_utils::destroy(lc);
     scenario.end();
@@ -118,8 +117,8 @@ fun test_insert_header_failed_difficulty_not_match() {
 
     // we changed the block hash to make new header previous hash not match with last hash
     let new_header = new_block_header(x"00801e31c24ae25304cbac7c3d3b076e241abb20ff2da1d3ddfc00000000000000000000530e6745eca48e937428b0f15669efdce807a071703ed5a4df0e85a3f6cc0f601c35cf665b25031880f1e351");
-    let current_block_hash = lc.head().header().block_hash();
-    lc.insert_header(current_block_hash, new_header);
+    let head_hash = lc.head_hash();
+    lc.insert_header(head_hash, new_header);
     sui::test_utils::destroy(lc);
     scenario.end();
 }
@@ -133,8 +132,8 @@ fun test_insert_header_failed_timestamp_too_old() {
 
     // we changed timestamp from 1c35cf66 to 0c35cf46
     let new_header = new_block_header(x"00801e31c24ae25304cbac7c3d3b076e241abb20ff2da1d3ddfc00000000000000000000530e6745eca48e937428b0f15669efdce807a071703ed5a4df0e85a3f6cc0f600c35cf465b25031780f1e351");
-    let current_block_hash = lc.head().header().block_hash();
-    lc.insert_header(current_block_hash, new_header);
+    let head_hash = lc.head_hash();
+    lc.insert_header(head_hash, new_header);
     sui::test_utils::destroy(lc);
     scenario.end();
 }

--- a/tests/light_client_tests.move
+++ b/tests/light_client_tests.move
@@ -37,8 +37,8 @@ fun test_set_get_block_happy_case() {
     let ctx = scenario.ctx();
     let lc = new_lc_for_test(ctx);
     let header = new_block_header(x"0060b0329fd61df7a284ba2f7debbfaef9c5152271ef8165037300000000000000000000562139850fcfc2eb3204b1e790005aaba44e63a2633252fdbced58d2a9a87e2cdb34cf665b250317245ddc6a");
-    assert!(lc.latest_height() == 858816);
-    assert!(lc.latest_block().header().block_hash() == header.block_hash());
+    assert!(lc.head_height() == 858816);
+    assert!(lc.head().header().block_hash() == header.block_hash());
     sui::test_utils::destroy(lc);
     scenario.end();
 }
@@ -70,8 +70,7 @@ fun test_insert_header_happy_cases() {
         x"00801e31c24ae25304cbac7c3d3b076e241abb20ff2da1d3ddfc00000000000000000000530e6745eca48e937428b0f15669efdce807a071703ed5a4df0e85a3f6cc0f601c35cf665b25031780f1e351"
     ];
     lc.insert_headers(raw_headers);
-    let latest_height = lc.latest_height();
-    let block_hash = lc.get_block_hash_by_height(latest_height);
+    let block_hash = lc.get_block_hash_by_height(lc.head_height());
 
     assert!(lc.get_light_block_by_hash(block_hash).header() == new_block_header(raw_headers[0]));
 
@@ -82,13 +81,13 @@ fun test_insert_header_happy_cases() {
         0,
     );
 
-    lc.set_latest_block(last_block);
+    lc.append_block(last_block);
     let headers = vector[
         x"006089239c7c45da6d872c93dc9e8389d52b04bdd0a824eb308002000000000000000000fb4c3ac894ebc99c7a7b76ded35ec1c719907320ab781689ba1dedca40c5a9d7c50de1668c09031716c80c0d"
     ];
 
     lc.insert_headers(headers);
-    assert!(lc.latest_block().header() == new_block_header(headers[0]));
+    assert!(lc.head().header() == new_block_header(headers[0]));
     sui::test_utils::destroy(lc);
     scenario.end();
 }
@@ -101,7 +100,7 @@ fun test_insert_header_failed_block_hash_not_match() {
     let mut lc = new_lc_for_test(scenario.ctx());
     // we changed the block hash to make new header previous hash not match with last hash
     let new_header = new_block_header(x"00801e31c24ae25304cbac7c3d3b076e241abb20ff2da1d3ddfc00000000000000000001530e6745eca48e937428b0f15669efdce807a071703ed5a4df0e85a3f6cc0f601c35cf665b25031780f1e351");
-    let current_block_hash = lc.latest_block().header().block_hash();
+    let current_block_hash = lc.head().header().block_hash();
     lc.insert_header(current_block_hash, new_header);
 
     sui::test_utils::destroy(lc);
@@ -117,7 +116,7 @@ fun test_insert_header_failed_difficulty_not_match() {
 
     // we changed the block hash to make new header previous hash not match with last hash
     let new_header = new_block_header(x"00801e31c24ae25304cbac7c3d3b076e241abb20ff2da1d3ddfc00000000000000000000530e6745eca48e937428b0f15669efdce807a071703ed5a4df0e85a3f6cc0f601c35cf665b25031880f1e351");
-    let current_block_hash = lc.latest_block().header().block_hash();
+    let current_block_hash = lc.head().header().block_hash();
     lc.insert_header(current_block_hash, new_header);
     sui::test_utils::destroy(lc);
     scenario.end();
@@ -132,7 +131,7 @@ fun test_insert_header_failed_timestamp_too_old() {
 
     // we changed timestamp from 1c35cf66 to 0c35cf46
     let new_header = new_block_header(x"00801e31c24ae25304cbac7c3d3b076e241abb20ff2da1d3ddfc00000000000000000000530e6745eca48e937428b0f15669efdce807a071703ed5a4df0e85a3f6cc0f600c35cf465b25031780f1e351");
-    let current_block_hash = lc.latest_block().header().block_hash();
+    let current_block_hash = lc.head().header().block_hash();
     lc.insert_header(current_block_hash, new_header);
     sui::test_utils::destroy(lc);
     scenario.end();

--- a/tests/light_client_tests.move
+++ b/tests/light_client_tests.move
@@ -70,9 +70,11 @@ fun test_insert_header_happy_cases() {
         x"00801e31c24ae25304cbac7c3d3b076e241abb20ff2da1d3ddfc00000000000000000000530e6745eca48e937428b0f15669efdce807a071703ed5a4df0e85a3f6cc0f601c35cf665b25031780f1e351"
     ];
     lc.insert_headers(raw_headers);
-    let block_hash = lc.get_block_hash_by_height(lc.head_height());
+    let latest_hash = lc.head_hash();
+    let latest_block = lc.get_light_block_by_hash(latest_hash).header();
 
-    assert!(lc.get_light_block_by_hash(block_hash).header() == new_block_header(raw_headers[0]));
+    assert!(latest_block == new_block_header(raw_headers[0]));
+    assert!(latest_block == lc.head().header());
 
     let last_block_header = new_block_header(x"0040a320aa52a8971f61e56bf5a45117e3e224eabfef9237cb9a0100000000000000000060a9a5edd4e39b70ee803e3d22673799ae6ec733ea7549442324f9e3a790e4e4b806e1665b250317807427ca");
     let last_block = new_light_block(

--- a/tests/light_client_tests.move
+++ b/tests/light_client_tests.move
@@ -25,7 +25,7 @@ fun new_lc_for_test(ctx: &mut TxContext) : LightClient {
         x"00800120451bed6d330bd942a708b0858fdbb7d265e5b7caa3c00000000000000000000025ba876f2efbd1522e36a7cd807879eeec843f95da8a01993556100e3226900b8d30cf66763d0317bd91acc5",
         x"0060b0329fd61df7a284ba2f7debbfaef9c5152271ef8165037300000000000000000000562139850fcfc2eb3204b1e790005aaba44e63a2633252fdbced58d2a9a87e2cdb34cf665b250317245ddc6a"
     ];
-    let lc = new_light_client_with_params_int(params::mainnet(), start_block, headers, 0,  ctx);
+    let lc = new_light_client_with_params_int(params::mainnet(), start_block, headers, 0, 8, ctx);
     return lc
 }
 

--- a/tests/transaction_test.move
+++ b/tests/transaction_test.move
@@ -56,7 +56,7 @@ fun verify_output_test() {
         x"02000000754bc32ac75a72d7937826fd285d3379f161f9e2b070dc270000000000000000ec39407a570b08b466f4427ad2f6006a044bcf86879ef18fc4d2ccb0d529d63425828b5342286918e5beaa62"
     ];
     let ctx = scenario.ctx();
-    let lc = new_light_client_with_params_int(params::mainnet(), start_block_height, headers, 0, ctx);
+    let lc = new_light_client_with_params_int(params::mainnet(), start_block_height, headers, 0, 8, ctx);
 
     // merkle proof of transaction id gen by proof.py in scripts folder.
     let proof = vector[x"1e895c00deb4d813d30be9e23a8ac3c2d3901848325a5b96f7a2d3c1b73e958c", x"3a84d14f294ccc02d86de520b5dd8f7da813f821f758c2e2163a9ddd9af6a60c", x"14fa91db83d517c8777a6d00081fa3e4f099eb27a1530c95c5e9c145ea0ed4b8", x"6d3df44f27ffa2de91ccb44a37a1ab5be183570e5c8fbf472fdd61cfc19260d7", x"dce5989b43fa75ec7bd131aa4a0d491ecc5e999a85e76561f2ac6f7077f2a1bd", x"7f1d7d3220d678b442b754b8e53976010866e94a727394fa524b704a434ae656", x"3ffea66faa79bd1044de8f9777c0ef45f126695892d070b12dce9f618c4881cb", x"3696323672a8c3db7fbc200bf64acfd3b336b105d298122d434579f646b6d5d5", x"86d7d18398c5de2c55e541bedbc78b2e8bf95637812ee0748c523c387d0f4ec8", x"537b0c8be17320ce64a35426d44614bd13e6b067c2d3d02f0159ce0046356c0b"];

--- a/tests/tx_verification_tests.move
+++ b/tests/tx_verification_tests.move
@@ -13,7 +13,7 @@ fun new_lc_for_test(ctx: &mut TxContext) : LightClient {
     let headers = vector[
         x"0060b0329fd61df7a284ba2f7debbfaef9c5152271ef8165037300000000000000000000562139850fcfc2eb3204b1e790005aaba44e63a2633252fdbced58d2a9a87e2cdb34cf665b250317245ddc6a"
     ];
-    let lc = new_light_client_with_params_int(params::mainnet(), start_block, headers, 0,  ctx);
+    let lc = new_light_client_with_params_int(params::mainnet(), start_block, headers, 0, 8, ctx);
     return lc
 }
 


### PR DESCRIPTION
Closes: #38 

+ renamed `latest_block` to `head` -- this is to follow the list nomenclature. In lists we have head - that is the latest / top element.
+ added `lc.head_hash()` view function
+ added `lc.finalized_height` view function
+ added head_hash to `InsertedHeadersEvent` event
+ added finality check that prevents extending the chain beyond the finality. NOTE: we may need to remove it  - probably we need to consult this with others.
