### PR TITLE
refactore: rename block_header::prev_block() to parent()

### DIFF
--- a/sources/block_header.move
+++ b/sources/block_header.move
@@ -32,7 +32,7 @@ public fun version(header: &BlockHeader): u32 {
     to_u32(header.slice(0, 4))
 }
 
-/// return parent block hash
+/// return parent block ID (hash)
 public fun prev_block(header: &BlockHeader): vector<u8> {
     header.slice(4, 36)
 }

--- a/sources/light_client.move
+++ b/sources/light_client.move
@@ -279,7 +279,7 @@ public fun head(lc: &LightClient): &LightBlock {
 
 /// Returns latest finalized_block height
 public fun finalized_height(lc: &LightClient): u64 {
-    lc.head_height - FINALITY
+    lc.head_height - lc.finality
 }
 
 /// verify output transaction


### PR DESCRIPTION
* rename prev_block function to parent - usually we refer to parent in the code, so for consistency we can use the same.
* fix one place where we use FINALITY const rather than filed