### PR TITLE
fix: bytes_of function

### DIFF
--- a/sources/btc_math.move
+++ b/sources/btc_math.move
@@ -93,7 +93,7 @@ fun bytes_of(number: u256) : u8 {
         b = b - 1;
     };
     // Follow logic in bitcoin core
-    ((b as u32 + 7 ) / 8) as u8
+    ((b as u32) / 8  + 1) as u8
 }
 
 
@@ -195,7 +195,7 @@ public fun covert_to_compact_size(number: u256): vector<u8> {
 // TODO: Check best practice to improve test
 #[test]
 fun bytes_of_test() {
-    assert!(bytes_of(0) == 0);
+    assert!(bytes_of(1) == 1);
     assert!(bytes_of(7) == 1);
     assert!(bytes_of(0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff) == 32);
 }

--- a/tests/btc_math_tests.move
+++ b/tests/btc_math_tests.move
@@ -73,6 +73,7 @@ fun bits_to_target_tests() {
     assert!(target == 0x00ffff0000000000000000000000000000000000000000000000000000000000);
     assert!(bits == target_to_bits(target));
 
+   // https://learnmeabitcoin.com/explorer/block/0000000000519051eb5f3c5943cdbc176a0eff4e1fbc3e08287bdb76299b8e5c
     let bits = 0x1c0168fd;
     let target = bits_to_target(bits);
     assert!(target == 0x000000000168fd00000000000000000000000000000000000000000000000000);

--- a/tests/btc_math_tests.move
+++ b/tests/btc_math_tests.move
@@ -72,6 +72,12 @@ fun bits_to_target_tests() {
     let target = bits_to_target(bits);
     assert!(target == 0x00ffff0000000000000000000000000000000000000000000000000000000000);
     assert!(bits == target_to_bits(target));
+
+    let bits = 0x1c0168fd;
+    let target = bits_to_target(bits);
+    assert!(target == 0x000000000168fd00000000000000000000000000000000000000000000000000);
+    assert!(bits == target_to_bits(target));
+
 }
 
 


### PR DESCRIPTION
The bytes_of function is incorrect, making target_to_bits also not a valid computation. This PR fixes the bytes_of function.