### PR TITLE
refactore: remove find_prev_testnet_difficulty

### DIFF
--- a/sources/btc_math.move
+++ b/sources/btc_math.move
@@ -95,7 +95,7 @@ fun bytes_of(number: u256) : u8 {
         b = b - 1;
     };
     // Follow logic in bitcoin core
-    ((b as u32) / 8  + 1) as u8
+    ((b as u32) / 8 + 1) as u8
 }
 
 

--- a/sources/light_client.move
+++ b/sources/light_client.move
@@ -237,7 +237,7 @@ public(package) fun insert_header(lc: &mut LightClient, parent: &LightBlock, hea
     assert!(parent_header.block_hash() == header.parent(), EWrongParentBlock);
     // NOTE: see comment in the skip_difficulty_check function
     if (!lc.params().skip_difficulty_check()) {
-        let next_block_difficulty = lc.calc_next_required_difficulty(parent, header.timestamp());
+        let next_block_difficulty = lc.calc_next_required_difficulty(parent);
         assert!(next_block_difficulty == header.bits(), EDifficultyNotMatch);
     };
 
@@ -390,7 +390,7 @@ public fun relative_ancestor(lc: &LightClient, lb: &LightBlock, distance: u64): 
 
 /// The function calculates the required difficulty for a block that we want to add after
 /// (potentially fork) after the parent_block.
-public fun calc_next_required_difficulty(lc: &LightClient, parent_block: &LightBlock, new_block_time: u32) : u32 {
+public fun calc_next_required_difficulty(lc: &LightClient, parent_block: &LightBlock) : u32 {
     // reference from https://github.com/btcsuite/btcd/blob/master/blockchain/difficulty.go#L136
     let params = lc.params();
     let blocks_pre_retarget = params.blocks_pre_retarget();
@@ -401,16 +401,6 @@ public fun calc_next_required_difficulty(lc: &LightClient, parent_block: &LightB
 
     // if this block does not start a new retarget cycle
     if ((parent_block.height() + 1) % blocks_pre_retarget != 0) {
-        if (params.adjust_difficulty()) {
-            let reduction_time = params.min_diff_reduction_time();
-            let allow_min_time = parent_block.header().timestamp() + reduction_time;
-            if (new_block_time > allow_min_time) {
-                return params.power_limit_bits()
-            };
-
-            return find_prev_testnet_difficulty(lc, parent_block)
-        };
-
         // Return previous block difficulty
         return parent_block.header().bits()
     };
@@ -427,32 +417,6 @@ public fun calc_next_required_difficulty(lc: &LightClient, parent_block: &LightB
     let new_bits = target_to_bits(new_target);
     new_bits
 }
-
-public(package) fun find_prev_testnet_difficulty(lc: &LightClient, start_node: &LightBlock): u32 {
-    let mut iter_block = start_node;
-    let blocks_pre_retarget = lc.params().blocks_pre_retarget();
-    let power_limit_bits = lc.params().power_limit_bits();
-
-    let mut height = iter_block.height();
-    let mut bits = iter_block.header().bits();
-
-    while (
-        height != 0 &&
-        height % blocks_pre_retarget != 0 &&
-        bits == power_limit_bits
-    ){
-        iter_block = lc.relative_ancestor(iter_block, 1); // parent_block
-        height = iter_block.height();
-        bits = iter_block.header().bits();
-    };
-
-    if (height != 0) {
-        return bits
-    };
-
-    power_limit_bits
-}
-
 
 fun calc_past_median_time(lc: &LightClient, lb: &LightBlock): u32 {
     // Follow implementation from btcsuite/btcd

--- a/sources/light_client.move
+++ b/sources/light_client.move
@@ -389,7 +389,7 @@ public fun relative_ancestor(lc: &LightClient, lb: &LightBlock, distance: u64): 
 }
 
 /// The function calculates the required difficulty for a block that we want to add after
-/// (potentially fork) after the parent_block.
+/// the `parent_block` (potentially fork).
 public fun calc_next_required_difficulty(lc: &LightClient, parent_block: &LightBlock) : u32 {
     // reference from https://github.com/btcsuite/btcd/blob/master/blockchain/difficulty.go#L136
     let params = lc.params();

--- a/sources/params.move
+++ b/sources/params.move
@@ -10,7 +10,6 @@ public struct Params has store {
     target_timespan: u64,
     pow_no_retargeting: bool,
     difficulty_adjustment: u8, // for Bitcoin testnet
-    min_diff_reduction_time: u32,  // time in seconds
 }
 
 const DifficultyAdjustment_Mainnet: u8 = 0; // mainnet
@@ -27,7 +26,6 @@ public fun mainnet(): Params {
         target_timespan: 2016 * 60 * 10, // ~ 2 weeks.
         pow_no_retargeting: false,
         difficulty_adjustment: DifficultyAdjustment_Mainnet,
-        min_diff_reduction_time: 0,
     }
 }
 
@@ -39,8 +37,7 @@ public fun testnet(): Params {
         blocks_pre_retarget: 2016,
         target_timespan: 2016 * 60 * 10, // ~ 2 weeks.
         pow_no_retargeting: false,
-        difficulty_adjustment: DifficultyAdjustment_V3,
-        min_diff_reduction_time: 20 * 60, // 20 minutes
+        difficulty_adjustment: DifficultyAdjustment_V3
     }
 }
 
@@ -53,8 +50,7 @@ public fun regtest(): Params {
         blocks_pre_retarget: 2016,
         target_timespan: 2016 * 60 * 10,  // ~ 2 weeks.
         pow_no_retargeting: true,
-        difficulty_adjustment: DifficultyAdjustment_Regtest,
-        min_diff_reduction_time: 20 * 60, // 20 minutes
+        difficulty_adjustment: DifficultyAdjustment_Regtest
     }
 }
 
@@ -78,16 +74,8 @@ public fun pow_no_retargeting(p: &Params): bool {
     p.pow_no_retargeting
 }
 
-public fun min_diff_reduction_time(p: &Params): u32 {
-    p.min_diff_reduction_time
-}
-
 public(package) fun is_correct_init_height(p: &Params, h: u64): bool {
     p.blocks_pre_retarget() == 0 || h % p.blocks_pre_retarget() == 0
-}
-
-public fun adjust_difficulty(p: &Params): bool {
-    p.difficulty_adjustment == DifficultyAdjustment_Regtest
 }
 
 // Instruments the logic to not verify the difficulty check

--- a/sources/params.move
+++ b/sources/params.move
@@ -8,7 +8,6 @@ public struct Params has store {
     blocks_pre_retarget: u64,
     /// time in seconds when we update the target
     target_timespan: u64,
-    pow_no_retargeting: bool,
     difficulty_adjustment: u8, // for Bitcoin testnet
 }
 
@@ -24,7 +23,6 @@ public fun mainnet(): Params {
         power_limit_bits: 0x1d00ffff,
         blocks_pre_retarget: 2016,
         target_timespan: 2016 * 60 * 10, // ~ 2 weeks.
-        pow_no_retargeting: false,
         difficulty_adjustment: DifficultyAdjustment_Mainnet,
     }
 }
@@ -36,7 +34,6 @@ public fun testnet(): Params {
         power_limit_bits: 0x1d00ffff,
         blocks_pre_retarget: 2016,
         target_timespan: 2016 * 60 * 10, // ~ 2 weeks.
-        pow_no_retargeting: false,
         difficulty_adjustment: DifficultyAdjustment_V3
     }
 }
@@ -49,7 +46,6 @@ public fun regtest(): Params {
         power_limit_bits: 0x207fffff,
         blocks_pre_retarget: 2016,
         target_timespan: 2016 * 60 * 10,  // ~ 2 weeks.
-        pow_no_retargeting: true,
         difficulty_adjustment: DifficultyAdjustment_Regtest
     }
 }
@@ -71,7 +67,7 @@ public fun target_timespan(p: &Params): u64 {
 }
 
 public fun pow_no_retargeting(p: &Params): bool {
-    p.pow_no_retargeting
+    p.difficulty_adjustment == DifficultyAdjustment_Regtest
 }
 
 public(package) fun is_correct_init_height(p: &Params, h: u64): bool {

--- a/tests/difficulty_tests.move
+++ b/tests/difficulty_tests.move
@@ -65,7 +65,7 @@ fun test_difficulty_computation_mainnet() {
     let block_hash = lc.get_block_hash_by_height(0);
 
     // The next difficulty at genesis block is equal power of limit.
-    assert!(calc_next_required_difficulty(&lc, lc.get_light_block_by_hash(block_hash), 0) == lc.params().power_limit_bits());
+    assert!(calc_next_required_difficulty(&lc, lc.get_light_block_by_hash(block_hash)) == lc.params().power_limit_bits());
 
     let header = new_block_header(x"0040a320aa52a8971f61e56bf5a45117e3e224eabfef9237cb9a0100000000000000000060a9a5edd4e39b70ee803e3d22673799ae6ec733ea7549442324f9e3a790e4e4b806e1665b250317807427ca");
     let last_block = new_light_block(
@@ -83,7 +83,7 @@ fun test_difficulty_computation_mainnet() {
     lc.append_block(first_block);
 
 
-    let new_bits = calc_next_required_difficulty(&lc, lc.get_light_block_by_hash(last_block_hash), 0);
+    let new_bits = calc_next_required_difficulty(&lc, lc.get_light_block_by_hash(last_block_hash));
 
     // 0x1703098c is bits of block 860832
     assert!(new_bits == 0x1703098c);
@@ -108,101 +108,8 @@ fun test_difficulty_computation_regtest() {
     );
 
     let block = lc.get_light_block_by_height(10);
-    let new_bits = calc_next_required_difficulty(&lc, block, 0);
+    let new_bits = lc.calc_next_required_difficulty(block);
     assert!(new_bits == lc.params().power_limit_bits());
-    sui::test_utils::destroy(lc);
-    scenario.end();
-}
-
-// TODO: update the test data to enable the test
-/* #[test]
-fun test_regtest_reset_dificulty() {
-    let sender = @0x01;
-    let mut scenario = test_scenario::begin(sender);
-
-    let lc = new_light_client(
-        params::regtest(),
-        10, // We use 10 because this not a block we adjust the target/difficulty. This is not random number!
-        // This header is random, we only care about timestamp in this case.
-        vector[x"000000207e50e267813c0b5849307d9a604a3250d122e5b25080950200000000000000007243a2960f9c5db0623a4b3c77a57bbe262d906e8d94dc837f032269bcaf8eeb77fd0058c440041806bc3f79"],
-        0,
-        8,
-        scenario.ctx()
-    );
-
-    let block = lc.get_light_block_by_height(10);
-    // auto reset difficulty/target after 20mins.
-    // params min_diff_reduction_time = 20mins in this case.
-    let new_bits = calc_next_required_difficulty(&lc, block, block.header().timestamp() + lc.params().min_diff_reduction_time() + 10);
-    assert!(new_bits == 0x1d00ffff);
-    sui::test_utils::destroy(lc);
-    scenario.end();
-}
-*/
-
-#[test]
-fun test_testnet_use_previous_difficulty() {
-    let sender = @0x01;
-    let mut scenario = test_scenario::begin(sender);
-
-    let lc = new_light_client(
-        params::testnet(),
-        10, // We use 10 because this not a block we adjust the target/difficulty. This is not random number!
-        // This header is random, we only care about timestamp in this case.
-        vector[x"000000207e50e267813c0b5849307d9a604a3250d122e5b25080950200000000000000007243a2960f9c5db0623a4b3c77a57bbe262d906e8d94dc837f032269bcaf8eeb77fd0058c440041806bc3f79"],
-        0,
-        8,
-        scenario.ctx()
-    );
-    let last_block = lc.get_light_block_by_height(10);
-    // testnet auto reset difficulty/target after 20mins.
-    // testnet params min_diff_reduction_time = 20mins in this case.
-    let new_bits = calc_next_required_difficulty(&lc, last_block, last_block.header().timestamp() + lc.params().min_diff_reduction_time() - 10);
-    assert!(new_bits == 0x180440c4);
-    sui::test_utils::destroy(lc);
-    scenario.end();
-}
-
-#[test]
-fun test_find_prev_testnet_difficulty() {
-    let sender = @0x01;
-    let mut scenario = test_scenario::begin(sender);
-
-    let mut lc = new_light_client(
-        params::testnet(),
-        2016,
-        // This header is random, we only care about timestamp and bits
-         vector[
-        x"000000207e50e267813c0b5849307d9a604a3250d122e5b25080950200000000000000007243a2960f9c5db0623a4b3c77a57bbe262d906e8d94dc837f032269bcaf8eeb77fd0058c440041806bc3f79",
-        x"000000207e50e267813c0b5849307d9a604a3250d122e5b25080950200000000000000007243a2960f9c5db0623a4b3c77a57bbe262d906e8d94dc837f032269bcaf8eeb77fd0058ffff001d06bc3f79",
-        x"000000207e50e267813c0b5849307d9a604a3250d122e5b25080950200000000000000007243a2960f9c5db0623a4b3c77a57bbe262d906e8d94dc837f032269bcaf8eeb77fd00587856341206bc3f79"
-    ],
-        0,
-        8,
-        scenario.ctx()
-    );
-
-
-    // the case last_block bits not equal powert limit
-    // we return bits of this block.
-    assert!(lc.find_prev_testnet_difficulty(lc.get_light_block_by_height(2018)) == 0x12345678);
-    // The case last_block bits equal power limit, return first block not equal power limit
-    // or the nearest retarget block (height % 2016 == 0);
-    assert!(lc.find_prev_testnet_difficulty(lc.get_light_block_by_height(2017)) == 0x180440c4);
-
-    let genesis_block = new_light_block(
-        0,
-        new_block_header(
-            x"0100000000000000000000000000000000000000000000000000000000000000000000003ba3edfd7a7b12b27ac72c3e67768f617fc81bc3888a51323a9fb8aa4b1e5e4a29ab5f49ffff001d1dac2b7c"
-        ),
-        0
-    );
-
-    lc.set_block_hash_by_height(0, genesis_block.header().block_hash());
-    lc.append_block(genesis_block);
-
-    // return power limit when genesis block
-    assert!(lc.find_prev_testnet_difficulty(lc.get_light_block_by_height(0)) == lc.params().power_limit_bits());
     sui::test_utils::destroy(lc);
     scenario.end();
 }


### PR DESCRIPTION
- Eliminate find_prev_testnet_difficulty for testnet since we no longer compute this. 
- Simplify the logic for adjusting difficulty, as regtest mode always returns power_limit_bits for difficulty computation.
- Remove the unused field in params.