### PR TITLE
math: use u64 for amounts

### DIFF
--- a/sources/light_client.move
+++ b/sources/light_client.move
@@ -337,7 +337,7 @@ public fun verify_output(
     output_count: u32,
     outputs: vector<u8>,
     lock_time: vector<u8>
-): (vector<vector<u8>>, vector<u256>) {
+): (vector<vector<u8>>, vector<u64>) {
     let tx = make_transaction(version, input_count, inputs, output_count, outputs, lock_time);
     assert!(lc.verify_tx(height, tx.tx_id(), proof, tx_index), ETxNotInBlock);
 
@@ -552,7 +552,7 @@ public fun verify_payment(
     tx_index: u64,
     transaction: &Transaction,
     receiver_address: vector<u8>
-) : (u256, vector<u8>, vector<u8>) {
+) : (u64, vector<u8>, vector<u8>) {
     let mut amount = 0;
     let mut op_return_msg = vector[];
     let tx_id = transaction.tx_id();

--- a/sources/transaction.move
+++ b/sources/transaction.move
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 module bitcoin_spv::transaction;
-use bitcoin_spv::btc_math::{btc_hash, u256_to_compact, to_number, compact_size};
+use bitcoin_spv::btc_math::{btc_hash, u256_to_compact, extract_u64, compact_size};
 use bitcoin_spv::utils::slice;
 
 // === BTC script opcodes ===
@@ -29,7 +29,7 @@ const OP_DATA_75: u8 = 0x4b;
 
 /// Represents a Bitcoin transaction output
 public struct Output has copy, drop {
-    amount: u256,
+    amount: u64,
     script_pubkey: vector<u8>
 }
 
@@ -86,7 +86,7 @@ public fun make_transaction(
     }
 }
 
-public fun parse_output(amount: u256, script_pubkey: vector<u8>): Output {
+public fun parse_output(amount: u64, script_pubkey: vector<u8>): Output {
     Output {
         amount,
         script_pubkey
@@ -101,7 +101,7 @@ public fun outputs(tx: &Transaction): vector<Output> {
     tx.outputs
 }
 
-public fun amount(output: &Output): u256 {
+public fun amount(output: &Output): u64 {
     output.amount
 }
 
@@ -176,7 +176,7 @@ public(package) fun make_outputs(output_count: u32, outputs_bytes: vector<u8>): 
         (script_pubkey_size, start) = compact_size(outputs_bytes, start);
         let script_pubkey = slice(outputs_bytes, start, (start + (script_pubkey_size as u64)));
         start = start + (script_pubkey_size as u64);
-        let output = parse_output(to_number(amount, 0, 8), script_pubkey);
+        let output = parse_output(extract_u64(amount, 0, 8), script_pubkey);
         outputs.push_back(output);
         i = i + 1;
     };

--- a/sources/utils.move
+++ b/sources/utils.move
@@ -9,7 +9,7 @@ const EOutBoundIndex: vector<u8> = b"The index 'n' is out of bounds for the vect
 
 /// slice() extracts up to but not including end.
 public fun slice(v: vector<u8>, start: u64, end: u64): vector<u8> {
-    // TODO: handle error when start,end position > length's v.
+    assert!(end <= v.length(), EOutBoundIndex);
     let mut ans = vector[];
     let mut i = start;
     while (i < end) {

--- a/tests/btc_math_tests.move
+++ b/tests/btc_math_tests.move
@@ -117,7 +117,7 @@ fun compact_size_tests() {
     let mut i = 0;
     while (i < inputs.length()) {
         let (x, y) = compact_size(inputs[i], 0);
-        assert!(x == outputs[i][0] && (y as u256) == outputs[i][1]);
+        assert!(x == outputs[i][0] && y == outputs[i][1]);
         i = i + 1;
     }
 


### PR DESCRIPTION
* change amount types to u64
* renamed `to_u256` to `extract_u64`
* added boundary checks in vector operations